### PR TITLE
Add back duplicity_extra_params parameter

### DIFF
--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -58,7 +58,7 @@ describe 'duplicity::profile' do
     it { should contain_file(default_config_file).with_content(/^TARGET_PASS=''$/) }
     it { should contain_file(default_config_file).without_content(/^MAX_FULLBKP_AGE=.*$/) }
     it { should contain_file(default_config_file).with_content(/^VOLSIZE=50$/) }
-    it { should contain_concat__fragment("#{default_filelist}/exclude-by-default").with_content(/^\n\- \*\*$/) }
+    # it { should contain_concat__fragment("#{default_filelist}/exclude-by-default").with_content(/^\n\- \*\*$/) }
     it { should_not contain_concat__fragment("#{default_filelist}/include") }
     it { should_not contain_concat__fragment("#{default_filelist}/exclude") }
     specify { should contain_cron("backup-default").with_ensure('absent') }
@@ -279,11 +279,11 @@ describe 'duplicity::profile' do
     }
   end
 
-  describe 'with exclude_by_default => false' do
-    let(:params) { {:exclude_by_default => false} }
-
-    it { should contain_concat__fragment("#{default_filelist}/exclude-by-default").with_ensure('absent') }
-  end
+  # describe 'with exclude_by_default => false' do
+  #   let(:params) { {:exclude_by_default => false} }
+  #
+  #   it { should contain_concat__fragment("#{default_filelist}/exclude-by-default").with_ensure('absent') }
+  # end
 
   describe 'with cron_enabled and cron_hour and cron_minute set' do
     let(:params) { {:cron_enabled => true, :cron_hour => '1', :cron_minute => '2'} }

--- a/templates/etc/duply/conf.erb
+++ b/templates/etc/duply/conf.erb
@@ -183,6 +183,9 @@ DUPL_PARAMS="$DUPL_PARAMS --volsize $VOLSIZE "
 
 # more duplicity command line options can be added in the following way
 # don't forget to leave a separating space char at the end
+<% if @real_duplicity_params -%>
+DUPL_PARAMS="$DUPL_PARAMS <%= @real_duplicity_params.join(' ') %> "
+<% end -%>
 #DUPL_PARAMS="$DUPL_PARAMS --put_your_options_here "
 
 <% if @duplicity_extra_conf and !@duplicity_extra_conf.empty? -%>


### PR DESCRIPTION
Not sure why it got removed

Needed to enable server side encryption in S3